### PR TITLE
Add caddy to reverse proxy list

### DIFF
--- a/src/docs/installation-reverse-proxies.md
+++ b/src/docs/installation-reverse-proxies.md
@@ -11,7 +11,7 @@ First setup Photoview via the regular docker-compose setup [here](https://photov
 
 ```
 photos.qpqp.dk {
-reverse_proxy http://qpqp.dk:8000
+reverse_proxy http://photos.qpqp.dk:8000
 }
 ```
 


### PR DESCRIPTION
I propose Caddy being first on the list because it automatically handles HTTPS, it's faster than apache, and because apache had that CVE a few days ago.