### PR TITLE
add example value for sqlite variable

### DIFF
--- a/src/en/docs/installation-environment-variables.md
+++ b/src/en/docs/installation-environment-variables.md
@@ -16,7 +16,7 @@ Environment variables related to configuration of the database.
 |                    | `PHOTOVIEW_DATABASE_DRIVER` | `mysql` | Available options `mysql` <small>(default)</small>, `postgres` and `sqlite`. <br/> Defines what database backend is used. One of the following **MUST** be set in addition to this variable.                     |
 | <center>✓</center> | `PHOTOVIEW_MYSQL_URL`       |         | Required if the driver is `mysql`. The URL of the MySQL database to connect to. See [formatting documentation](https://github.com/go-sql-driver/mysql#dsn-data-source-name).                                     |
 | <center>✓</center> | `PHOTOVIEW_POSTGRES_URL`    |         | Required if the driver is `postgres`. The connection string of the Postgres database to connect to. See [formatting documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING). |
-| <center>✓</center> | `PHOTOVIEW_SQLITE_PATH`     |         | Required if the driver is `sqlite`. Specifies the filepath for where the sqlite database should be saved.                                                                                                        |
+| <center>✓</center> | `PHOTOVIEW_SQLITE_PATH`     |         | Required if the driver is `sqlite`. Specifies the filepath for where the sqlite database should be saved. Example value: `/app/database/photoview.db`      |
 
 ## Server related
 

--- a/src/fr/docs/installation-environment-variables.md
+++ b/src/fr/docs/installation-environment-variables.md
@@ -15,7 +15,7 @@ Cette page présente toutes ces variables avec une description.
 |                    | `PHOTOVIEW_DATABASE_DRIVER` | `mysql` | Choix du driver de base de données : `mysql`<small>(par défaut)</small>, `postgres` et `sqlite`. <br/> Définit quelle base de données est utilisée. Une des variables ci-dessous **DOIT** être également renseignée pour que le système fonctionne.                     |
 | <center>✓</center> | `PHOTOVIEW_MYSQL_URL`       |         | Requis si le driver est `mysql`. L'URL de la base de données MySQL à laquelle se connecter. Voir [formatting documentation](https://github.com/go-sql-driver/mysql#dsn-data-source-name).                                     |
 | <center>✓</center> | `PHOTOVIEW_POSTGRES_URL`    |         | Requis si le driver est `postgres`. La chaine de connexion de la base Postgres à laquelle se connecter. Voir [formatting documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING). |
-| <center>✓</center> | `PHOTOVIEW_SQLITE_PATH`     |         | Requis si le driver est `sqlite`. Spécifie le _filepath_ sur lequel la base de données sqlite doit être enregistrée.                       |
+| <center>✓</center> | `PHOTOVIEW_SQLITE_PATH`     |         | Requis si le driver est `sqlite`. Spécifie le _filepath_ sur lequel la base de données sqlite doit être enregistrée. Valeur par exemple: `/app/database/photoview.db`                      |
 
 ## Variables liées au serveur
 


### PR DESCRIPTION
I was trying to use `sqlite` (and I gave up eventually because of the too many locked DB errors https://github.com/photoview/photoview/issues/618) and the first time I tried it I added here a directory (even if it clearly say the `filepath`).

I believe this can make it more explicit.

Found the example in this issue: https://github.com/photoview/photoview/issues/768#issuecomment-1459922305.

I will also raise a PR to add a commented line in the `docker-compose.yaml` volumes section that explains the sqlite binding.