### PR TITLE
Update installation-manual.md and installation-systemd.md

### DIFF
--- a/src/en/docs/installation-manual.md
+++ b/src/en/docs/installation-manual.md
@@ -129,6 +129,8 @@ We will use that to configure Photoview.
 
 Copy the `api/example.env` file to the output directory, and name it `.env`.
 
+> Note: If running Photoview as a `systemd` service, the file containing environment variables is `/etc/photoview.env` and is created in the steps outlined in the [systemd installation guide](/{{ locale }}/docs/installation-systemd/).
+
 ```shell
 $ cp api/example.env app/.env
 ```

--- a/src/en/docs/installation-manual.md
+++ b/src/en/docs/installation-manual.md
@@ -73,7 +73,7 @@ $ npm install
 $ npm run build
 ```
 
-This builds the UI source code and saves it in the `ui/build/` directory.
+This builds the UI source code and saves it in the `ui/dist/` directory.
 
 ### Build the API back-end
 
@@ -91,7 +91,7 @@ Make a new directory and move the needed files to it.
 ```shell
 $ cd /opt/photoview
 $ mkdir app
-$ cp -r ui/build/ app/ui/
+$ cp -r ui/dist/ app/ui/
 $ cp api/photoview app/photoview
 $ cp -r api/data/ app/data/
 ```

--- a/src/en/docs/installation-manual.md
+++ b/src/en/docs/installation-manual.md
@@ -86,7 +86,7 @@ This builds the server executable to `api/photoview`.
 
 ### Copy needed files
 
-**Note**: To run Photoview as a `systemd` service, copy files as outlined in the [systemd installation guide](/{{ locale }}/docs/installation-systemd/). Otherwise, follow the steps here.
+> Note: To run Photoview as a `systemd` service, copy files as outlined in the [systemd installation guide](/{{ locale }}/docs/installation-systemd/). Otherwise, follow the steps here.
 
 Make a new directory and move the needed files to it.
 

--- a/src/en/docs/installation-manual.md
+++ b/src/en/docs/installation-manual.md
@@ -98,7 +98,7 @@ $ cp api/photoview app/photoview
 $ cp -r api/data/ app/data/
 ```
 
-## Setup database
+## Set up database
 
 > It's highly recommended to configure a full database,
 > but Sqlite is also supported though it might be substantially slower on big media libraries.

--- a/src/en/docs/installation-manual.md
+++ b/src/en/docs/installation-manual.md
@@ -48,10 +48,10 @@ $ go version
 # Expected output: go version go1.16 linux/amd64
 ```
 
-Now install Node 16 and NPM if you've not done so already (it installs npm automatically)
+Now install Node 18 and NPM if you've not done so already (it installs npm automatically)
 
 ```shell
-$ curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+$ curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
 $ sudo apt install nodejs
 ```
 

--- a/src/en/docs/installation-manual.md
+++ b/src/en/docs/installation-manual.md
@@ -27,7 +27,7 @@ $ sudo add-apt-repository ppa:strukturag/libde265
 
 # Install dependencies required to build and run Photoview
 $ sudo apt install libdlib-dev libblas-dev libatlas-base-dev liblapack-dev libjpeg-turbo8-dev build-essential \
-  libdlib19 libdlib-dev libblas-dev libatlas-base-dev liblapack-dev libjpeg-dev libheif-dev pkg-config gpg
+  libdlib19 libdlib-dev libblas-dev libatlas-base-dev liblapack-dev libjpeg-dev libheif-dev pkg-config gpg zlib1g-dev
 ```
 
 Install Golang by following the instructions for Linux from their [Download and install Go](https://golang.org/doc/install) page, the steps should be something like the following.

--- a/src/en/docs/installation-manual.md
+++ b/src/en/docs/installation-manual.md
@@ -86,6 +86,8 @@ This builds the server executable to `api/photoview`.
 
 ### Copy needed files
 
+**Note**: To run Photoview as a `systemd` service, copy files as outlined in the [systemd installation guide](/{{ locale }}/docs/installation-systemd/). Otherwise, follow the steps here.
+
 Make a new directory and move the needed files to it.
 
 ```shell

--- a/src/en/docs/installation-systemd.md
+++ b/src/en/docs/installation-systemd.md
@@ -56,7 +56,7 @@ $ sudo install -Dm0644 "/opt/photoview/systemd/photoview.tmpfiles" "/usr/lib/tmp
 $ sudo install -d "/var/cache/photoview/media_cache"
 # The next line is if you plan to use `sqlite`
 $ sudo install -d "/var/lib/photoview"
-$ cd /opt/photoview/ui/build
+$ cd /opt/photoview/ui/dist
 $ sudo find * -type f -exec install -Dm0644 "{}" "/usr/share/webapps/photoview-ui/{}" \;
 $ cd /opt/photoview/api
 $ sudo install -Dm0755 -t "/usr/lib/photoview" "/opt/photoview/api/photoview"

--- a/src/en/docs/installation-systemd.md
+++ b/src/en/docs/installation-systemd.md
@@ -29,6 +29,8 @@ If you do so, the `photoview.service` and `photoview.tmpfiles` will need to be a
 
 > Reminder: These steps replace [Copy needed files](#copy-needed-files) from the manual installation guide.
 
+1. Create the `photoview` user and group
+   - `$ sudo adduser photoview --system --group --no-create-home`
 1. Copy `systemd` files:
    - `systemd/photoview.service` to `/etc/systemd/system/multi-user.target/photoview.service`
    - `systemd/photoview.sysusers.conf` to `/usr/lib/sysusers.d/photoview.conf`
@@ -49,6 +51,7 @@ If you do so, the `photoview.service` and `photoview.tmpfiles` will need to be a
 
 A synopsis of the previous steps by example:
 ```shell
+$ sudo adduser photoview --system --group --no-create-home
 $ cd /opt/photoview
 $ sudo install -Dm0644 -t "/usr/lib/systemd/system" "/opt/photoview/systemd/photoview.service"
 $ sudo install -Dm0644 "/opt/photoview/systemd/photoview.sysusers.conf" "/usr/lib/sysusers.d/photoview.conf"

--- a/src/en/docs/installation-systemd.md
+++ b/src/en/docs/installation-systemd.md
@@ -9,8 +9,8 @@ You can optionally use `systemd` to manage photoview and start the program at bo
 It also allows the program to run as its own system user, enhancing the security of the process.
 
 
-To get started, follow the [Manual Setup Installation guild](/{{ locale }}/docs/installation-manual/).
-When you get to the _Copy needed files section_, replace those steps with the steps listed below.
+To get started, follow the [Manual Setup Installation guide](/{{ locale }}/docs/installation-manual/).
+When you get to the _Copy needed files_ section, replace those steps with the steps listed below.
 
 ## Using with `systemd`
 

--- a/src/en/docs/installation-systemd.md
+++ b/src/en/docs/installation-systemd.md
@@ -57,8 +57,10 @@ $ sudo install -Dm0644 -t "/usr/lib/systemd/system" "/opt/photoview/systemd/phot
 $ sudo install -Dm0644 "/opt/photoview/systemd/photoview.sysusers.conf" "/usr/lib/sysusers.d/photoview.conf"
 $ sudo install -Dm0644 "/opt/photoview/systemd/photoview.tmpfiles" "/usr/lib/tmpfiles.d/photoview.conf"
 $ sudo install -d "/var/cache/photoview/media_cache"
-# The next line is if you plan to use `sqlite`
+$ sudo chown -R photoview:photoview /var/cache/photoview
+# The next two lines are if you plan to use `sqlite`
 $ sudo install -d "/var/lib/photoview"
+$ sudo chown -R photoview:photoview /var/lib/photoview
 $ cd /opt/photoview/ui/dist
 $ sudo find * -type f -exec install -Dm0644 "{}" "/usr/share/webapps/photoview-ui/{}" \;
 $ cd /opt/photoview/api

--- a/src/en/docs/installation-systemd.md
+++ b/src/en/docs/installation-systemd.md
@@ -35,7 +35,7 @@ If you do so, the `photoview.service` and `photoview.tmpfiles` will need to be a
    - `systemd/photoview.service` to `/etc/systemd/system/multi-user.target/photoview.service`
    - `systemd/photoview.sysusers.conf` to `/usr/lib/sysusers.d/photoview.conf`
    - `systemd/photoview.tmpfiles` to `/usr/lib/tmpfiles.d/photoview.conf`
-   > If you do not plan to use `sqlite`, remove the 2nd line from `systemd/photoview.tmpfiles` before copying.
+   > If you do not plan to use `sqlite`, remove the 2nd line from `systemd/photoview.tmpfiles` and comment out the line `ReadWritePaths=/var/lib/photoview` in `systemd/photoview.service` before copying.
 1. Make the directories where the program files will be placed :
    > Note: The `install` command, as demonstrated below, creates these required directories for you.
    - `/usr/share/webapps/photoview-ui`

--- a/src/en/docs/installation-systemd.md
+++ b/src/en/docs/installation-systemd.md
@@ -58,9 +58,6 @@ $ sudo install -Dm0644 "/opt/photoview/systemd/photoview.sysusers.conf" "/usr/li
 $ sudo install -Dm0644 "/opt/photoview/systemd/photoview.tmpfiles" "/usr/lib/tmpfiles.d/photoview.conf"
 $ sudo install -d "/var/cache/photoview/media_cache"
 $ sudo chown -R photoview:photoview /var/cache/photoview
-# The next two lines are if you plan to use `sqlite`
-$ sudo install -d "/var/lib/photoview"
-$ sudo chown -R photoview:photoview /var/lib/photoview
 $ cd /opt/photoview/ui/dist
 $ sudo find * -type f -exec install -Dm0644 "{}" "/usr/share/webapps/photoview-ui/{}" \;
 $ cd /opt/photoview/api
@@ -68,6 +65,9 @@ $ sudo install -Dm0755 -t "/usr/lib/photoview" "/opt/photoview/api/photoview"
 $ sudo ln -s /usr/lib/photoview/photoview /usr/bin/photoview
 $ sudo find data -type f -exec install -Dm0644 "{}" "/usr/lib/photoview/{}" \;
 $ sudo install -Dm0644 "/opt/photoview/api/example.env" "/etc/photoview.env"
+# The next two lines are if you plan to use `sqlite`
+$ sudo install -d "/var/lib/photoview"
+$ sudo chown -R photoview:photoview /var/lib/photoview
 ```
 ### Using the `systemd` unit file
 

--- a/src/fr/docs/installation-manual.md
+++ b/src/fr/docs/installation-manual.md
@@ -72,7 +72,7 @@ $ npm install
 $ npm run build
 ```
 
-Cela build le code source de l'UI et l'enregistre dans le répertoire `ui/build/`.
+Cela build le code source de l'UI et l'enregistre dans le répertoire `ui/dist/`.
 
 ### Buildez l'API back-end
 
@@ -90,7 +90,7 @@ Créez un nouveau répertoire et deplacez les fichiers créés dedans.
 ```shell
 $ cd /opt/photoview
 $ mkdir app
-$ cp -r ui/build/ app/ui/
+$ cp -r ui/dist/ app/ui/
 $ cp api/photoview app/photoview
 $ cp -r api/data/ app/data/
 ```

--- a/src/fr/docs/installation-manual.md
+++ b/src/fr/docs/installation-manual.md
@@ -47,10 +47,10 @@ $ go version
 # Expected output: go version go1.16 linux/amd64
 ```
 
-Maintenant, installez Node 16 et NPM si vous ne les avez pas déjà installés sur votre système.
+Maintenant, installez Node 18 et NPM si vous ne les avez pas déjà installés sur votre système.
 
 ```shell
-$ curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+$ curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
 $ sudo apt install nodejs
 ```
 

--- a/src/fr/docs/installation-manual.md
+++ b/src/fr/docs/installation-manual.md
@@ -85,6 +85,8 @@ Cela build l'executable côté serveur et l'enregistre dans `api/photoview`.
 
 ### Copiez UI et back-end au bon endroit
 
+> Si vous choisissez d'utiliser `systemd`, suivez le [Utilisation avec systemd](/{{ locale }}/docs/installation-systemd/).
+
 Créez un nouveau répertoire et deplacez les fichiers créés dedans.
 
 ```shell

--- a/src/fr/docs/installation-manual.md
+++ b/src/fr/docs/installation-manual.md
@@ -26,7 +26,7 @@ $ sudo add-apt-repository ppa:strukturag/libde265
 
 # Installation des dépendances nécessaires pour Photoview
 $ sudo apt install libdlib-dev libblas-dev libatlas-base-dev liblapack-dev libjpeg-turbo8-dev build-essential \
-  libdlib19 libdlib-dev libblas-dev libatlas-base-dev liblapack-dev libjpeg-dev libheif-dev pkg-config gpg
+  libdlib19 libdlib-dev libblas-dev libatlas-base-dev liblapack-dev libjpeg-dev libheif-dev pkg-config gpg zlib1g-dev
 ```
 
 Installez ensuite Golang en suivant les instructions pour Linux depuis leur page [Download and install Go](https://golang.org/doc/install), cela devrait ressembler aux commandes suivantes :

--- a/src/fr/docs/installation-systemd.md
+++ b/src/fr/docs/installation-systemd.md
@@ -36,7 +36,7 @@ Il faudra alors faire attention de répercuter ces changement dans les variables
    - `systemd/photoview.service` vers `/etc/systemd/system/multi-user.target/photoview.service`
    - `systemd/photoview.sysusers.conf` vers `/usr/lib/sysusers.d/photoview.conf`
    - `systemd/photoview.tmpfiles` vers `/usr/lib/tmpfiles.d/photoview.conf`
-   > Si vous n'utilisez pas `sqlite`, supprimez la 2ème ligne de `systemd/photoview.tmpfiles` avant la copie.
+   > Si vous n'utilisez pas `sqlite`, supprimez la 2ème ligne de `systemd/photoview.tmpfiles` et la ligne `ReadWritePaths=/var/lib/photoview` de `systemd/photoview.service` avant la copie.
 1. Créez les répertoires dans lesquels les fichiers du programme seront placés :
    > A noter : la commande `install`, comme expliqué ci-dessous, crée les répertoires requis.
    - `/usr/share/webapps/photoview-ui`

--- a/src/fr/docs/installation-systemd.md
+++ b/src/fr/docs/installation-systemd.md
@@ -58,8 +58,7 @@ $ sudo install -Dm0644 -t "/usr/lib/systemd/system" "/opt/photoview/systemd/phot
 $ sudo install -Dm0644 "/opt/photoview/systemd/photoview.sysusers.conf" "/usr/lib/sysusers.d/photoview.conf"
 $ sudo install -Dm0644 "/opt/photoview/systemd/photoview.tmpfiles" "/usr/lib/tmpfiles.d/photoview.conf"
 $ sudo install -d "/var/cache/photoview/media_cache"
-# The next line is if you plan to use `sqlite`
-$ sudo install -d "/var/lib/photoview"
+$ sudo chown -R photoview:photoview /var/cache/photoview
 $ cd /opt/photoview/ui/dist
 $ sudo find * -type f -exec install -Dm0644 "{}" "/usr/share/webapps/photoview-ui/{}" \;
 $ cd /opt/photoview/api
@@ -67,6 +66,9 @@ $ sudo install -Dm0755 -t "/usr/lib/photoview" "/opt/photoview/api/photoview"
 $ sudo ln -s /usr/lib/photoview/photoview /usr/bin/photoview
 $ sudo find data -type f -exec install -Dm0644 "{}" "/usr/lib/photoview/{}" \;
 $ sudo install -Dm0644 "/opt/photoview/api/example.env" "/etc/photoview.env"
+# Seulement si vous utilisez `sqlite`:
+$ sudo install -d "/var/lib/photoview"
+$ sudo chown -R photoview:photoview /var/lib/photoview
 ```
 ### Utiliser le fichier `systemd`
 

--- a/src/fr/docs/installation-systemd.md
+++ b/src/fr/docs/installation-systemd.md
@@ -57,7 +57,7 @@ $ sudo install -Dm0644 "/opt/photoview/systemd/photoview.tmpfiles" "/usr/lib/tmp
 $ sudo install -d "/var/cache/photoview/media_cache"
 # The next line is if you plan to use `sqlite`
 $ sudo install -d "/var/lib/photoview"
-$ cd /opt/photoview/ui/build
+$ cd /opt/photoview/ui/dist
 $ sudo find * -type f -exec install -Dm0644 "{}" "/usr/share/webapps/photoview-ui/{}" \;
 $ cd /opt/photoview/api
 $ sudo install -Dm0755 -t "/usr/lib/photoview" "/opt/photoview/api/photoview"

--- a/src/fr/docs/installation-systemd.md
+++ b/src/fr/docs/installation-systemd.md
@@ -30,6 +30,8 @@ Il faudra alors faire attention de répercuter ces changement dans les variables
 
 > Rappel : Ces étapes remplacent celles de la rubrique _Copiez UI et back-end au bon endroit_ du guide d'installation manuelle.
 
+1. Créez l'utilisateur et le groupe `photoview`:
+   - `$ sudo adduser photoview --system --group --no-create-home`
 1. Copiez les fichiers `systemd`:
    - `systemd/photoview.service` vers `/etc/systemd/system/multi-user.target/photoview.service`
    - `systemd/photoview.sysusers.conf` vers `/usr/lib/sysusers.d/photoview.conf`
@@ -50,6 +52,7 @@ Il faudra alors faire attention de répercuter ces changement dans les variables
 
 Exemple de ce que donnent ces étapes :
 ```shell
+$ sudo adduser photoview --system --group --no-create-home
 $ cd /opt/photoview
 $ sudo install -Dm0644 -t "/usr/lib/systemd/system" "/opt/photoview/systemd/photoview.service"
 $ sudo install -Dm0644 "/opt/photoview/systemd/photoview.sysusers.conf" "/usr/lib/sysusers.d/photoview.conf"


### PR DESCRIPTION
This pull request makes the following changes:
- `installation-manual.md` (English and French versions):
	- Change path `ui/build` to `ui/dist`
	- Add `zlib1g-dev` to dependencies (required by `libheif`)
	- Add note referring to `systemd` instructions in "Copy needed files" section
	- Change Node 16 to Node 18
- `installation-manual.md` (English version only):
	- Change format of note under "Copy needed files" section to match other notes in documentation
	- Fix typo
	- Add note with env file location in "Configure Photoview" section
- `installation-systemd.md` (English and French versions):
	- Change path `ui/build` to `ui/dist`
	- Add step to create `photoview` user and group
	- Add `chown` commands to synopsis of steps
	- Move steps re `sqlite` to end of synopsis for clarity
	- Add instruction to comment `ReadWritePaths` line in `photoview.service` if not using `sqlite`
- `installation-systemd.md` (English version only):
	- Correct typos