### PR TITLE
fix: broken docker-compose.example.yml links

### DIFF
--- a/src/en/docs/getting-started/getting-started.md
+++ b/src/en/docs/getting-started/getting-started.md
@@ -13,7 +13,7 @@ The easiest way to setup Photoview is using Docker with docker-compose.
 
 ### Configure compose file
 
-Make a new `docker-compose.yml` file, and copy the content of [docker-compose.example.yml](https://github.com/photoview/photoview/blob/master/docker-compose.example.yml) to it.
+Make a new `docker-compose.yml` file, and copy the content of [docker-compose.example.yml](https://github.com/photoview/photoview/blob/master/docker-compose%20example/docker-compose.example.yml) to it.
 
 Edit `docker-compose.yml`, find the comments starting with `Change This:`, and change the values, to properly match your setup. If you are just testing locally, you don't have to change anything.
 

--- a/src/en/docs/getting-started/getting-started.md
+++ b/src/en/docs/getting-started/getting-started.md
@@ -13,7 +13,7 @@ The easiest way to setup Photoview is using Docker with docker-compose.
 
 ### Configure compose file
 
-Make a new `docker-compose.yml` file, and copy the content of [docker-compose.example.yml](https://github.com/photoview/photoview/blob/master/docker-compose%20example/docker-compose.example.yml) to it.
+Make a new `docker-compose.yml` file, and copy the content of [docker-compose.example.yml](https://github.com/photoview/photoview/blob/master/docker-compose%20example/docker-compose.example.yml) (MariaDB/Postgres/Sqlite and Watchtower) or [docker-compose.minimal.example.yml](https://github.com/photoview/photoview/blob/master/docker-compose%20example/docker-compose.minimal.example.yml) (MariaDB/Sqlite) to it.
 
 Edit `docker-compose.yml`, find the comments starting with `Change This:`, and change the values, to properly match your setup. If you are just testing locally, you don't have to change anything.
 

--- a/src/en/docs/installation-docker.md
+++ b/src/en/docs/installation-docker.md
@@ -21,8 +21,8 @@ Although this tool can't do anything you can't already to with Docker alone, it 
 > Prerequisite: Docker Engine and Docker Compose is installed on your server.
 > See [Install Docker Engine][docker-install] and [Install Docker Compose][install-docker-compose] on how to do so.
 
-To configure Photoview using Docker Compose, first copy the contents of [docker-compose.example.yml](https://github.com/photoview/photoview/blob/master/docker-compose%20example/docker-compose.example.yml),
-and save it to a file called `docker-compose.yml`.
+To configure Photoview using Docker Compose, first copy the contents of either the [docker-compose.example.yml][docker-compose.example.yml] or [docker-compose.minimal.example.yml][docker-compose.minimal.example.yml] ,
+and save it to a file called `docker-compose.yml`. The minimal version uses MariaDB, while the full example also includes commented out Postgres and Watchtower containers.
 
 Within the file you will find two services: the Photoview server itself named `photoview` and a MariaDB database named `db`.
 The Photoview service is already configured with the database.
@@ -90,6 +90,7 @@ $ docker-compose ps   # show status of the running containers
 [install-docker-compose]: https://docs.docker.com/compose/install/
 [docker-bind-mount]: https://docs.docker.com/storage/bind-mounts/
 [docker-compose.example.yml]: https://github.com/photoview/photoview/blob/master/docker-compose%20example/docker-compose.example.yml
+[docker-compose.minimal.example.yml]: https://github.com/photoview/photoview/blob/master/docker-compose%20example/docker-compose.minimal.example.yml
 [mapbox-access-token]: https://account.mapbox.com/access-tokens/
 
 ## Docker tags and versioning

--- a/src/en/docs/installation-docker.md
+++ b/src/en/docs/installation-docker.md
@@ -89,7 +89,7 @@ $ docker-compose ps   # show status of the running containers
 [docker-install]: https://docs.docker.com/engine/install/
 [install-docker-compose]: https://docs.docker.com/compose/install/
 [docker-bind-mount]: https://docs.docker.com/storage/bind-mounts/
-[docker-compose.example.yml]: https://github.com/photoview/photoview/blob/master/docker-compose.example.yml
+[docker-compose.example.yml]: https://github.com/photoview/photoview/blob/master/docker-compose%20example/docker-compose.example.yml
 [mapbox-access-token]: https://account.mapbox.com/access-tokens/
 
 ## Docker tags and versioning

--- a/src/fr/docs/getting-started/getting-started.md
+++ b/src/fr/docs/getting-started/getting-started.md
@@ -13,7 +13,7 @@ Le moyen le plus simple pour installer **Photoview** est d'utiliser Docker avec 
 
 ### Configurer le fichier docker-compose
 
-Commencez par créer un nouveau fichier `docker-compose.yml`, puis collez-y le contenu du fichier [docker-compose.example.yml](https://github.com/photoview/photoview/blob/master/docker-compose%20example/docker-compose.example.yml).
+Commencez par créer un nouveau fichier `docker-compose.yml`, puis collez-y le contenu du fichier [docker-compose.example.yml](https://github.com/photoview/photoview/blob/master/docker-compose%20example/docker-compose.example.yml) (MariaDB/Postgres/Sqlite et Watchtower) ou [docker-compose.minimal.example.yml](https://github.com/photoview/photoview/blob/master/docker-compose%20example/docker-compose.minimal.example.yml) (MariaDB/Sqlite).
 
 Ouvrez le fichier `docker-compose.yml`, trouvez les commentaires commençant par `Change This:`, puis modifiez les valeurs pour qu'elles correspondent à votre configuration.
 Si vous faites simplement des tests sur votre machine en local, vous n'avez rien à modifier, laissez les valeurs telles quelles.

--- a/src/fr/docs/getting-started/getting-started.md
+++ b/src/fr/docs/getting-started/getting-started.md
@@ -13,7 +13,7 @@ Le moyen le plus simple pour installer **Photoview** est d'utiliser Docker avec 
 
 ### Configurer le fichier docker-compose
 
-Commencez par créer un nouveau fichier `docker-compose.yml`, puis collez-y le contenu du fichier [docker-compose.example.yml](https://github.com/photoview/photoview/blob/master/docker-compose.example.yml).
+Commencez par créer un nouveau fichier `docker-compose.yml`, puis collez-y le contenu du fichier [docker-compose.example.yml](https://github.com/photoview/photoview/blob/master/docker-compose%20example/docker-compose.example.yml).
 
 Ouvrez le fichier `docker-compose.yml`, trouvez les commentaires commençant par `Change This:`, puis modifiez les valeurs pour qu'elles correspondent à votre configuration.
 Si vous faites simplement des tests sur votre machine en local, vous n'avez rien à modifier, laissez les valeurs telles quelles.

--- a/src/fr/docs/installation-docker.md
+++ b/src/fr/docs/installation-docker.md
@@ -84,7 +84,7 @@ $ docker-compose ps   # show status of the running containers
 [docker-install]: https://docs.docker.com/engine/install/
 [install-docker-compose]: https://docs.docker.com/compose/install/
 [docker-bind-mount]: https://docs.docker.com/storage/bind-mounts/
-[docker-compose.example.yml]: https://github.com/photoview/photoview/blob/master/docker-compose.example.yml
+[docker-compose.example.yml]: https://github.com/photoview/photoview/blob/master/docker-compose%20example/docker-compose.example.yml
 [mapbox-access-token]: https://account.mapbox.com/access-tokens/
 
 ## Docker tags et versioning

--- a/src/fr/docs/installation-docker.md
+++ b/src/fr/docs/installation-docker.md
@@ -21,7 +21,7 @@ Bien que cet outil ne puisse rien faire que vous ne puissiez déjà faire avec D
 > Prérequis : Docker Engine et Docker Compose doivent être installés sur votre serveur.
 > Voir [Install Docker Engine][docker-install] et [Install Docker Compose][install-docker-compose] pour savoir comment les installer.
 
-Pour configurer Photoview avec Docker Compose, copiez tout d'abord le contenu du fichier [docker-compose.example.yml][docker-compose.example.yml], et collez-le dans un nouveau fichier `docker-compose.yml`.
+Pour configurer Photoview avec Docker Compose, commencez par copier le contenu soit du fichier [docker-compose.example.yml][docker-compose.example.yml], soit du fichier [docker-compose.minimal.example.yml][docker-compose.minimal.example.yml], et enregistrez-le dans un fichier nommé docker-compose.yml. La version minimale utilise MariaDB, tandis que l'exemple complet inclut également des conteneurs Postgres et Watchtower commentés.
 
 Dans ce fichier vous trouverez deux services : le serveur Photoview, appelé `photoview` et une base de données MariaDB database appelée `db`.
 Le service Photoview est déjà configuré avec la base de données.
@@ -85,6 +85,7 @@ $ docker-compose ps   # show status of the running containers
 [install-docker-compose]: https://docs.docker.com/compose/install/
 [docker-bind-mount]: https://docs.docker.com/storage/bind-mounts/
 [docker-compose.example.yml]: https://github.com/photoview/photoview/blob/master/docker-compose%20example/docker-compose.example.yml
+[docker-compose.minimal.example.yml]: https://github.com/photoview/photoview/blob/master/docker-compose%20example/docker-compose.minimal.example.yml
 [mapbox-access-token]: https://account.mapbox.com/access-tokens/
 
 ## Docker tags et versioning


### PR DESCRIPTION
The links to the docker compose example are currently broken