### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Website and documentation for [Photoview](https://github.com/photoview/photoview
 ## Contributing
 
 Pull requests that improve or expand the documentation is much appreciated.
-The documentation is written in markdown, located under [./src/docs/](./src/docs).
+The documentation is written in markdown, located under [./src/en/docs](./src/en/docs). 
 
 To build and test the site locally, run the following commands.
 


### PR DESCRIPTION
Path to docs source is updated in README.md (old one was used before French localization was introduced, so it ended up being a broken link).